### PR TITLE
Update Dockerfile and dependencies: upgrade Ruby to 3.4, bump ka-ching-client to 0.7.0, and update backend image to latest

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,7 +14,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15-alpine
+        image: postgres:17-alpine
         ports: ["5432:5432"]
         env:
           POSTGRES_USER: kaching
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3-slim
+FROM ruby:3.4-slim
 
 RUN apt-get update && apt-get install -y \
     build-essential \

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'bigdecimal', '~> 3.2'
-gem 'ka-ching-client', '~> 0.6.7'
+gem 'ka-ching-client', '~> 0.7.0'
 gem 'money', '~> 6.16'
 gem 'puma', '~> 6.6'
 gem 'rack-unreloader', '~> 2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,11 +4,11 @@ GEM
     ast (2.4.3)
     backport (1.2.0)
     benchmark (0.4.1)
-    bigdecimal (3.2.2)
+    bigdecimal (3.2.3)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     diff-lcs (1.6.2)
-    faraday (2.13.3)
+    faraday (2.13.4)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -22,7 +22,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.6.1)
     json (2.13.2)
-    ka-ching-client (0.6.7)
+    ka-ching-client (0.7.0)
       faraday (>= 2.7.10, < 2.14.0)
       httpx (>= 1.0.0, < 1.6.0)
     kramdown (2.5.1)
@@ -52,14 +52,14 @@ GEM
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
-    prism (1.4.0)
+    prism (1.5.1)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
     puma (6.6.1)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.2.0)
+    rack (3.2.1)
     rack-unreloader (2.1.0)
     rackup (2.2.1)
       rack (>= 3)
@@ -70,10 +70,10 @@ GEM
     regexp_parser (2.11.2)
     reverse_markdown (3.0.0)
       nokogiri
-    rexml (3.4.1)
-    roda (3.95.0)
+    rexml (3.4.4)
+    roda (3.96.0)
       rack
-    rubocop (1.80.1)
+    rubocop (1.80.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -114,9 +114,9 @@ GEM
       yard-solargraph (~> 0.1)
     thor (1.4.0)
     tilt (2.6.1)
-    unicode-display_width (3.1.5)
-      unicode-emoji (~> 4.0, >= 4.0.4)
-    unicode-emoji (4.0.4)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.1.0)
     uri (1.0.3)
     yard (0.9.37)
     yard-solargraph (0.1.0)
@@ -130,7 +130,7 @@ PLATFORMS
 DEPENDENCIES
   bigdecimal (~> 3.2)
   htmlbeautifier (~> 1.4)
-  ka-ching-client (~> 0.6.7)
+  ka-ching-client (~> 0.7.0)
   money (~> 6.16)
   pry (~> 0.15.2)
   puma (~> 6.6)
@@ -143,4 +143,4 @@ DEPENDENCIES
   solargraph (~> 0.56.2)
 
 BUNDLED WITH
-   2.6.5
+   2.7.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   frontend:
     tty: true
@@ -25,7 +23,7 @@ services:
         condition: service_started
 
   backend:
-    image: ghcr.io/simonneutert/ka-ching-backend:v0.6.7
+    image: ghcr.io/simonneutert/ka-ching-backend:latest
     environment:
       DATABASE_URL: db
       DATABASE_USER: kaching
@@ -38,7 +36,7 @@ services:
         condition: service_healthy
 
   db:
-    image: postgres:16-alpine
+    image: postgres:17-alpine
     environment:
       POSTGRES_USER: kaching
       POSTGRES_PASSWORD: kaching

--- a/views/tenants.erb
+++ b/views/tenants.erb
@@ -11,7 +11,7 @@
       <% else %>
         <div class="container">
           <div class="select">
-            <select id="select-tenant" hx-on="change: window.location.href = (document.getElementById('select-tenant').options[document.getElementById('select-tenant').selectedIndex].value) + '/actions'">
+            <select id="select-tenant" onchange="window.location.href = this.value + '/actions'">
               <option value="" disabled selected hidden>Choose a tenant</option>
               <% @tenants.each do |tenant| %>
                 <option value="<%= tenant %>"><%= tenant %></option>


### PR DESCRIPTION
BUGFIX

SELECTING A TENANT (AUTOJUMP)

HTMX2.0.2 seemed to have broken automatic tenant selection.

This is fixed and works as intended by now again.

---

This pull request updates several dependencies and configuration files to use newer versions, ensuring compatibility and security improvements across the stack. The changes affect Docker, Ruby, PostgreSQL, and related service images, as well as a small optimization in the frontend view logic.

**Dependency and service upgrades:**

* Updated the Ruby base image in the `Dockerfile` from `ruby:3.3-slim` to `ruby:3.4-slim` to use the latest Ruby version.
* Changed the `ka-ching-client` gem version in the `Gemfile` from `~> 0.6.7` to `~> 0.7.0` for improved client functionality and compatibility.
* Updated the backend service image in `docker-compose.yml` from a specific version (`v0.6.7`) to `latest`, ensuring the backend uses the most recent release.

**PostgreSQL upgrades:**

* Upgraded the PostgreSQL image in both `.github/workflows/ruby.yml` (for CI) and `docker-compose.yml` (for local development) from version 15/16 to 17-alpine for improved performance and security. [[1]](diffhunk://#diff-ce0dee93a528f6c7648f4cd671a3ec7be6a80f976c88f3aa1c322b7a80828fbaL17-R17) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L41-R39)

**CI and frontend improvements:**

* Updated GitHub Actions checkout step in `.github/workflows/ruby.yml` from `actions/checkout@v3` to `@v5` for better performance and security.
* Simplified the tenant selection logic in `views/tenants.erb` by replacing the custom `hx-on` attribute with a standard `onchange` event handler.